### PR TITLE
Move fatal logs from prom2json file to main

### DIFF
--- a/cmd/prom2json/main.go
+++ b/cmd/prom2json/main.go
@@ -19,8 +19,10 @@ import (
 	"fmt"
 	"os"
 
-	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/log"
+
+	dto "github.com/prometheus/client_model/go"
+
 	"github.com/prometheus/prom2json"
 )
 

--- a/cmd/prom2json/main.go
+++ b/cmd/prom2json/main.go
@@ -19,10 +19,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/prometheus/common/log"
-
 	dto "github.com/prometheus/client_model/go"
-
+	"github.com/prometheus/common/log"
 	"github.com/prometheus/prom2json"
 )
 
@@ -41,7 +39,12 @@ func main() {
 
 	mfChan := make(chan *dto.MetricFamily, 1024)
 
-	go prom2json.FetchMetricFamilies(flag.Args()[0], mfChan, *cert, *key, *skipServerCertCheck)
+	go func() {
+		err := prom2json.FetchMetricFamilies(flag.Args()[0], mfChan, *cert, *key, *skipServerCertCheck)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}()
 
 	result := []*prom2json.Family{}
 	for mf := range mfChan {

--- a/prom2json.go
+++ b/prom2json.go
@@ -8,10 +8,8 @@ import (
 	"net/http"
 
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
-	"github.com/prometheus/common/expfmt"
-	"github.com/prometheus/common/log"
-
 	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
 )
 
 const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3`
@@ -125,13 +123,13 @@ func FetchMetricFamilies(
 	url string, ch chan<- *dto.MetricFamily,
 	certificate string, key string,
 	skipServerCertCheck bool,
-) {
+) error {
 	defer close(ch)
 	var transport *http.Transport
 	if certificate != "" && key != "" {
 		cert, err := tls.LoadX509KeyPair(certificate, key)
 		if err != nil {
-			log.Fatal(err)
+			return err
 		}
 		tlsConfig := &tls.Config{
 			Certificates:       []tls.Certificate{cert},
@@ -145,30 +143,30 @@ func FetchMetricFamilies(
 		}
 	}
 	client := &http.Client{Transport: transport}
-	decodeContent(client, url, ch)
+	return decodeContent(client, url, ch)
 }
 
-func decodeContent(client *http.Client, url string, ch chan<- *dto.MetricFamily) {
+func decodeContent(client *http.Client, url string, ch chan<- *dto.MetricFamily) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		log.Fatalf("creating GET request for URL %q failed: %s", url, err)
+		return fmt.Errorf("creating GET request for URL %q failed: %s", url, err)
 	}
 	req.Header.Add("Accept", acceptHeader)
 	resp, err := client.Do(req)
 	if err != nil {
-		log.Fatalf("executing GET request for URL %q failed: %s", url, err)
+		return fmt.Errorf("executing GET request for URL %q failed: %s", url, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		log.Fatalf("GET request for URL %q returned HTTP status %s", url, resp.Status)
+		return fmt.Errorf("GET request for URL %q returned HTTP status %s", url, resp.Status)
 	}
-	ParseResponse(resp, ch)
+	return ParseResponse(resp, ch)
 }
 
 // ParseResponse consumes an http.Response and pushes it to the MetricFamily
 // channel. It returns when all all MetricFamilies are parsed and put on the
 // channel.
-func ParseResponse(resp *http.Response, ch chan<- *dto.MetricFamily) {
+func ParseResponse(resp *http.Response, ch chan<- *dto.MetricFamily) error {
 	mediatype, params, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
 	if err == nil && mediatype == "application/vnd.google.protobuf" &&
 		params["encoding"] == "delimited" &&
@@ -179,7 +177,7 @@ func ParseResponse(resp *http.Response, ch chan<- *dto.MetricFamily) {
 				if err == io.EOF {
 					break
 				}
-				log.Fatalln("reading metric family protocol buffer failed:", err)
+				return fmt.Errorf("reading metric family protocol buffer failed: %v", err)
 			}
 			ch <- mf
 		}
@@ -190,12 +188,13 @@ func ParseResponse(resp *http.Response, ch chan<- *dto.MetricFamily) {
 		var parser expfmt.TextParser
 		metricFamilies, err := parser.TextToMetricFamilies(resp.Body)
 		if err != nil {
-			log.Fatalln("reading text format failed:", err)
+			return fmt.Errorf("reading text format failed: %v", err)
 		}
 		for _, mf := range metricFamilies {
 			ch <- mf
 		}
 	}
+	return nil
 }
 
 // AddLabel allows to add key/value labels to an already existing Family.

--- a/prom2json.go
+++ b/prom2json.go
@@ -8,8 +8,9 @@ import (
 	"net/http"
 
 	"github.com/matttproud/golang_protobuf_extensions/pbutil"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
+
+	dto "github.com/prometheus/client_model/go"
 )
 
 const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3`
@@ -149,12 +150,12 @@ func FetchMetricFamilies(
 func decodeContent(client *http.Client, url string, ch chan<- *dto.MetricFamily) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return fmt.Errorf("creating GET request for URL %q failed: %s", url, err)
+		return fmt.Errorf("creating GET request for URL %q failed: %v", url, err)
 	}
 	req.Header.Add("Accept", acceptHeader)
 	resp, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("executing GET request for URL %q failed: %s", url, err)
+		return fmt.Errorf("executing GET request for URL %q failed: %v", url, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
This PR moves fatal logs from the prom2json functions to the main.
Indeed, the prom2json functions can be used as a library and the `log.Fatal` stops the program which calls it.

The modifications allow removing the fatal behavior from the prom2json and manage the errors in the main.
Thus, the current behavior of prom2json is not modified.

WDYT @beorn7 ?