### PR TITLE
Use the interface type `RoundTripper` in `FetchMetricFamilies`

### DIFF
--- a/prom2json.go
+++ b/prom2json.go
@@ -144,15 +144,15 @@ func makeBuckets(m *dto.Metric) map[string]string {
 
 // FetchMetricFamilies retrieves metrics from the provided URL, decodes them
 // into MetricFamily proto messages, and sends them to the provided channel. It
-// returns after all MetricFamilies have been sent. The provided http.Transport
+// returns after all MetricFamilies have been sent. The provided transport
 // may be nil (in which case the default Transport is used).
-func FetchMetricFamilies(url string, ch chan<- *dto.MetricFamily, t *http.Transport) error {
+func FetchMetricFamilies(url string, ch chan<- *dto.MetricFamily, transport http.RoundTripper) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("creating GET request for URL %q failed: %v", url, err)
 	}
 	req.Header.Add("Accept", acceptHeader)
-	client := http.Client{Transport: t}
+	client := http.Client{Transport: transport}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("executing GET request for URL %q failed: %v", url, err)


### PR DESCRIPTION
If using `Transport`, the `nil` detection doesn't work anymore.

Signed-off-by: beorn7 <bjoern@rabenste.in>

@maxim0r as promised.