### PR TITLE
Close metric family channel in case of errors

### DIFF
--- a/prom2json.go
+++ b/prom2json.go
@@ -149,16 +149,19 @@ func makeBuckets(m *dto.Metric) map[string]string {
 func FetchMetricFamilies(url string, ch chan<- *dto.MetricFamily, transport http.RoundTripper) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
+		close(ch)
 		return fmt.Errorf("creating GET request for URL %q failed: %v", url, err)
 	}
 	req.Header.Add("Accept", acceptHeader)
 	client := http.Client{Transport: transport}
 	resp, err := client.Do(req)
 	if err != nil {
+		close(ch)
 		return fmt.Errorf("executing GET request for URL %q failed: %v", url, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
+		close(ch)
 		return fmt.Errorf("GET request for URL %q returned HTTP status %s", url, resp.Status)
 	}
 	return ParseResponse(resp, ch)


### PR DESCRIPTION
`FetchMetricFamilies` never closes the channel if the request fails or can't be constructed correctly (lines 153, 160 and 165). In these cases `ch` is never closed and the caller will probably leak a goroutine when used as a library. This fix doesn't break backwards compatibility.

We can't add a `defer close(ch)` in line 150 because `ParseResponse` itself also closes the channel.