### PR TITLE
docs: add example of reading inputs from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Example query to retrieve the number of metrics in the `http_requests_total` met
 
     $ prom2json http://my-prometheus-client.example.org:8080/metrics | jq '.[]|select(.name=="http_requests_total")|.metrics|length'
 
+Example input from stdin:
+
+    $ curl http://my-prometheus-client.example.org:8080/metrics | grep http_requests_total | prom2json
+
 # JSON format
 
 Note that all numbers are encoded as strings. Some parsers want it

--- a/cmd/prom2json/main.go
+++ b/cmd/prom2json/main.go
@@ -29,12 +29,23 @@ import (
 	"github.com/prometheus/prom2json"
 )
 
-var usage = fmt.Sprintf(`Usage: %s [METRICS_PATH | METRICS_URL [--cert CERT_PATH --key KEY_PATH | --accept-invalid-cert]]`, os.Args[0])
+var usage = fmt.Sprintf(`Usage: %s [METRICS_PATH | METRICS_URL [--cert CERT_PATH --key KEY_PATH | --accept-invalid-cert]]
+
+Example:
+
+	$ prom2json http://my-prometheus-server:9000/metrics
+
+	$ curl http://my-prometheus-server:9000/metrics | prom2json
+	
+`, os.Args[0])
 
 func main() {
 	cert := flag.String("cert", "", "client certificate file")
 	key := flag.String("key", "", "client certificate's key file")
 	skipServerCertCheck := flag.Bool("accept-invalid-cert", false, "Accept any certificate during TLS handshake. Insecure, use only for testing.")
+	flag.Usage = func() {
+		fmt.Fprint(os.Stderr, usage)
+	}
 	flag.Parse()
 
 	var input io.Reader
@@ -66,7 +77,6 @@ func main() {
 	}
 
 	mfChan := make(chan *dto.MetricFamily, 1024)
-
 	// Missing input means we are reading from an URL.
 	if input != nil {
 		go func() {


### PR DESCRIPTION
I needed this to read metrics from stdin, but was confused earlier since it wasn't documented on the docs or in cli help. 