### PR TITLE
fixes #189 Use %w in fmt.Errorf() to avoid context loss

### DIFF
--- a/prom2json.go
+++ b/prom2json.go
@@ -179,14 +179,14 @@ func FetchMetricFamilies(url string, ch chan<- *dto.MetricFamily, transport http
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		close(ch)
-		return fmt.Errorf("creating GET request for URL %q failed: %v", url, err)
+		return fmt.Errorf("creating GET request for URL %q failed: %w", url, err)
 	}
 	req.Header.Add("Accept", acceptHeader)
 	client := http.Client{Transport: transport}
 	resp, err := client.Do(req)
 	if err != nil {
 		close(ch)
-		return fmt.Errorf("executing GET request for URL %q failed: %v", url, err)
+		return fmt.Errorf("executing GET request for URL %q failed: %w", url, err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -211,7 +211,7 @@ func ParseResponse(resp *http.Response, ch chan<- *dto.MetricFamily) error {
 				if err == io.EOF {
 					break
 				}
-				return fmt.Errorf("reading metric family protocol buffer failed: %v", err)
+				return fmt.Errorf("reading metric family protocol buffer failed: %w", err)
 			}
 			ch <- mf
 		}


### PR DESCRIPTION
The current implementation of prometheus/prom2json passes generic string errors, which can make it difficult to accurately diagnose and resolve issues in dependent code. 

This pull request addresses this by:

Wrapping errors: Implementing error wrapping to preserve valuable context and provide more informative error messages.
