### PR TITLE
Add option to negotiate UTF-8 names

### DIFF
--- a/cmd/prom2json/main.go
+++ b/cmd/prom2json/main.go
@@ -44,6 +44,8 @@ func main() {
 	cert := kingpin.Flag("cert", "client certificate file").String()
 	key := kingpin.Flag("key", "client certificate's key file").String()
 	skipServerCertCheck := kingpin.Flag("accept-invalid-cert", "Accept any certificate during TLS handshake. Insecure, use only for testing.").Bool()
+	negotiateUTF8 := kingpin.Flag("negotiate-utf-8", "During HTTP content negotiation, allow the target to use any UTF-8 characters in metric and label names. If not set, the target is supposed to escape non-standard characters. prom2json will accept all UTF-8 characters in any case.").Bool()
+
 	kingpin.CommandLine.UsageWriter(os.Stderr)
 	kingpin.Version(version.Print("prom2json"))
 	kingpin.HelpFlag.Short('h')
@@ -88,7 +90,12 @@ func main() {
 			os.Exit(1)
 		}
 		go func() {
-			err := prom2json.FetchMetricFamilies(*arg, mfChan, transport)
+			var err error
+			if *negotiateUTF8 {
+				err = prom2json.FetchMetricFamiliesUTF8(*arg, mfChan, transport)
+			} else {
+				err = prom2json.FetchMetricFamilies(*arg, mfChan, transport)
+			}
 			if err != nil {
 				fmt.Fprintln(os.Stderr, err)
 				os.Exit(1)

--- a/prom2json.go
+++ b/prom2json.go
@@ -27,7 +27,10 @@ import (
 	"github.com/prometheus/prom2json/histogram"
 )
 
-const acceptHeader = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3`
+const (
+	acceptHeaderLegacy = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;q=0.7,text/plain;version=0.0.4;q=0.3`
+	acceptHeaderUTF8   = `application/vnd.google.protobuf;proto=io.prometheus.client.MetricFamily;encoding=delimited;escaping=allow-utf-8;q=0.7,text/plain;version=0.0.4;escaping=allow-utf-8;q=0.3`
+)
 
 // Family mirrors the MetricFamily proto message.
 type Family struct {
@@ -177,12 +180,27 @@ func makeBuckets(m *dto.Metric) map[string]string {
 // returns after all MetricFamilies have been sent. The provided transport
 // may be nil (in which case the default Transport is used).
 func FetchMetricFamilies(url string, ch chan<- *dto.MetricFamily, transport http.RoundTripper) error {
+	return fetchMetricFamilies(url, ch, transport, false)
+}
+
+// FetchMetricFamiliesUTF8 works like FetchMetricFamilies but negotiates UTF-8
+// names.
+func FetchMetricFamiliesUTF8(url string, ch chan<- *dto.MetricFamily, transport http.RoundTripper) error {
+	return fetchMetricFamilies(url, ch, transport, true)
+}
+
+func fetchMetricFamilies(
+	url string, ch chan<- *dto.MetricFamily, transport http.RoundTripper, negotiateUTF8 bool) error {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		close(ch)
 		return fmt.Errorf("creating GET request for URL %q failed: %w", url, err)
 	}
-	req.Header.Add("Accept", acceptHeader)
+	if negotiateUTF8 {
+		req.Header.Add("Accept", acceptHeaderUTF8)
+	} else {
+		req.Header.Add("Accept", acceptHeaderLegacy)
+	}
 	client := http.Client{Transport: transport}
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Due to its simplistic design, prom2json has always tolerated any characters in metric and label names. (It does not validate anything, just puts strings into JSON objects…)

However, a compliant scrape target will only serve unescaped UTF-8 in names if asked to do so. This commit adds a CLI option to make prom2json ask for it.

We cannot set this option by default without a major release because users might depend on the escaping.

I implemented this in a slightly clunky way to not change the library API (although we use semver for the user API, not the library API here – I still thought we can be nice at a relatively small price).