### PR TITLE
build: add distroless image variant

### DIFF
--- a/Dockerfile.distroless
+++ b/Dockerfile.distroless
@@ -1,0 +1,22 @@
+ARG DISTROLESS_ARCH="amd64"
+
+FROM gcr.io/distroless/static-debian13:nonroot-${DISTROLESS_ARCH}
+# Base image sets USER to 65532:65532 (nonroot user).
+
+ARG ARCH="amd64"
+ARG OS="linux"
+
+LABEL org.opencontainers.image.authors="The Prometheus Authors"
+LABEL org.opencontainers.image.vendor="Prometheus"
+LABEL org.opencontainers.image.title="prom2json"
+LABEL org.opencontainers.image.description="A tool to scrape a Prometheus client and dump the result as JSON."
+LABEL org.opencontainers.image.source="https://github.com/prometheus/prom2json"
+LABEL org.opencontainers.image.url="https://github.com/prometheus/prom2json"
+LABEL org.opencontainers.image.documentation="https://github.com/prometheus/prom2json"
+LABEL org.opencontainers.image.licenses="Apache License 2.0"
+LABEL io.prometheus.image.variant="distroless"
+
+COPY LICENSE NOTICE /
+COPY .build/${OS}-${ARCH}/prom2json /bin/prom2json
+
+ENTRYPOINT [ "/bin/prom2json" ]


### PR DESCRIPTION
The distroless image runs as nonroot (UID 65532) without a shell, reducing the attack surface compared to the busybox-based image.