### PR TITLE
Update build.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    # Exclude configs synced from upstream prometheus/prometheus.
+    exclude-paths:
+      - .github/workflows/container_description.yml
+      - .github/workflows/golangci-lint.yml
+      - .github/workflows/scorecards.yml
+      - .github/workflows/stale.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,15 @@ jobs:
     name: Go tests
     runs-on: ubuntu-latest
     container:
-      # Whenever the Go version is updated here, .promu.yml should also be updated.
-      image: quay.io/prometheus/golang-builder:1.25-base
+      # Whenever the Go version is updated here, .promu.yml
+      # should also be updated.
+      image: quay.io/prometheus/golang-builder:1.26-base
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
-      - run: make SKIP_GOLANGCI_LINT=1
+      - run: make GO_ONLY=1 SKIP_GOLANGCI_LINT=1
       - run: git diff --exit-code
 
   build:
@@ -29,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        thread: [0, 1, 2, 3]
+        thread: [ 0, 1, 2, 3]
     steps:
       - uses: prometheus/promci/build@d9d4f5688814f0b77bf003d07fb8c00507390634 # v0.8.2
         with:
@@ -49,22 +50,23 @@ jobs:
     steps:
       - uses: prometheus/promci/publish_main@d9d4f5688814f0b77bf003d07fb8c00507390634 # v0.8.2
         with:
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_password: ${{ secrets.docker_hub_password }}
           ghcr_io_password: ${{ github.token }}
-          quay_io_password: ${{ secrets.QUAY_IO_PASSWORD }}
+          quay_io_password: ${{ secrets.quay_io_password }}
 
   publish_release:
-    name: Publish release artifacts
+    name: Publish release artefacts
     runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write
     needs: [test_go, build]
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     steps:
       - uses: prometheus/promci/publish_release@d9d4f5688814f0b77bf003d07fb8c00507390634 # v0.8.2
         with:
-          docker_hub_password: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          docker_hub_password: ${{ secrets.docker_hub_password }}
           ghcr_io_password: ${{ github.token }}
-          quay_io_password: ${{ secrets.QUAY_IO_PASSWORD }}
+          quay_io_password: ${{ secrets.quay_io_password }}
           github_token: ${{ github.token }}

--- a/.promu.yml
+++ b/.promu.yml
@@ -1,8 +1,8 @@
 ---
 go:
     # Whenever the Go version is updated here
-    # .circle/config.yml should also be updated.
-    version: 1.25
+    # .github/workflows/ci.yml should also be updated.
+    version: 1.26
 repository:
     path: github.com/prometheus/prom2json
 build:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/prometheus/prom2json
 
-go 1.24.9
+go 1.25.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
* Update PromCI from upstream example.
* Update Go for 1.26.
* Enable dependabot for GitHub actions.